### PR TITLE
fixes zip.

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -124,8 +124,8 @@
 (define tail cdr)
 
 
-(define (zip . lsts)
-  (apply map list lsts))
+(define (zip lst . lsts)
+  (apply map list lst lsts))
 
 
 (define (zip-with proc list1 . lists)


### PR DESCRIPTION
Implemntation of zip introduced in c85d7c523b6 was broken as it was possible to call zip without arguments that was causing error when map of list was applied to empty lsts. Requiering of at least one list passed to procedure seems to be making sense.