### PR TITLE
Optimize `scanr` for improved performance

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -122,13 +122,13 @@
    (rest lst)))
 
 
-; TODO optimize
 (define (scanr proc lst)
-  (foldr
-   (λ (val acc)
-     (append (list (proc val (first acc))) acc))
-   (list (last lst))
-   (init lst)))
+  (foldl
+   (λ (a acc)
+     (cond ((null? acc) (cons a acc))
+           (else (cons (proc a (car acc)) acc))))
+   '()
+   (reverse lst)))
 
 
 (define (sorted? lst)


### PR DESCRIPTION
This pull request addresses the TODO comment in the code to further optimize the `scanr` algorithm. The function has been refactored to run `foldl` on a reversed version of the input list, rather than use `foldr` as did the previous implementation. The optimized version also makes use of `cons` to add to the accumulator list, rather than call convert the added element to a separate list and using `append`.

The performance analysis detail is below. The test was performed by calling the `scanr` function on a 2,000,000 element list for 50 cycles.

- original scanr: CPU Time: 20,720 ms | Real Time: 20,733 ms | GC Time: 15,265 ms
- optimized scanr: CPU Time: 4,226 ms | Real Time: 4,231 ms | GC Time: 2,701 ms

All `raco` unit tests have been run successfully.

Note: The original implementation made use of the `first` function. The testing showed that this increased execution time by about 26%. However, I want to acknowledge that there may be a reason that this is preferred that I am not aware of. I believe the difference is due to `first` implementing a guard to ensure it is only called on lists while `car` is missing the same guard.

Please do with this request as you like. I am a fan of this library, and I was hoping to help.