### PR TITLE
Optimize `sliding`

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -103,7 +103,7 @@
 
 (define (sliding xs n [step 1])
   (when (or (<= step 0) (> step (length xs)))
-    (error "step has to be positive and equal to or smaller than the length of the list"))
+    (error "step has to be equal to or smaller than the length of the list"))
 
   (let recur [(xs xs)
               (len (length xs))]

--- a/main.rkt
+++ b/main.rkt
@@ -102,6 +102,9 @@
 
 
 (define (sliding xs n [step 1])
+  (when (or (<= step 0) (> step (length xs)))
+    (error "step has to be positive and equal to or smaller than the length of the list"))
+
   (let recur [(xs xs)
               (len (length xs))]
     (if (>= len n)

--- a/main.rkt
+++ b/main.rkt
@@ -101,15 +101,15 @@
   (flatten (zip-with make-list lst lst2)))
 
 
-(define (sliding xs n [step 1])
-  (when (or (<= step 0) (> step (length xs)))
+(define (sliding lst size [step 1])
+  (when (or (<= step 0) (> step (length lst)))
     (error "step has to be equal to or smaller than the length of the list"))
 
-  (let recur [(xs xs)
-              (len (length xs))]
-    (if (>= len n)
-      (cons (take xs n)
-            (recur (drop xs step)
+  (let recur [(lst lst)
+              (len (length lst))]
+    (if (>= len size)
+      (cons (take lst size)
+            (recur (drop lst step)
                    (- len step)))
       empty)))
 

--- a/main.rkt
+++ b/main.rkt
@@ -101,17 +101,14 @@
   (flatten (zip-with make-list lst lst2)))
 
 
-(define (sliding lst size [step 1])
-  (define (tail-call lst)
-    (if (>= size (length lst))
-        (list lst)
-        (cons (take lst size)
-              (tail-call (drop lst step)))))
-  (cond
-    [(> step (length lst))
-      (error "step has to be equal to or smaller than length of the list")]
-    [(= step (length lst)) (list lst)]
-    [else (tail-call lst)]))
+(define (sliding xs n [step 1])
+  (let recur [(xs xs)
+              (len (length xs))]
+    (if (>= len n)
+      (cons (take xs n)
+            (recur (drop xs step)
+                   (- len step)))
+      empty)))
 
 
 (define (scanl proc lst)


### PR DESCRIPTION
## Performance

- Time complexity: from O(N² /  step) to O((N / step) * (size + step))
- Space complexity: from O(N / step + N) to O(N / step + N)

_* If my analysis is correct_
 
## Changes

`length` may be quite fast, even on large inputs, but it's still O(N), making the total time complexity quadratic. I tested this change in my Markov chain implementation, and it made a meaningful performance difference on large corpora without any apparent regressions.

While accumulating in reverse order may have lead to better space complexity due to TCO, the `reverse` in the base case or expensive `append` negates any difference made in time, so the results are inconsistent; if order doesn't matter, it can cut the time in half. In my defense, the previous version didn't use TCO despite having a subprocedure called `tail-call`, because the self-call was wrapped in cons.

I'm sure we can squeeze more performance still, but probably only a modest asymptotic or even constant factor difference and will make the logic less clear. Any input is welcome.