### PR TITLE
fix: CI, conflicting arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           version: 'stable'
 
       - name: Install dependencies
-        run: raco pkg install --auto --deps fail --name algorithms
+        run: raco pkg install --auto --name algorithms
 
       - name: Run tests
         run: raco test -x -p algorithms


### PR DESCRIPTION
This is getting embarrassing... I fixed the conflicting arguments for raco (`--auto` and `--deps fail`), but seemingly overrode it in a later commit, PRing the broken code... I'm so sorry for having wasted your time. Thank you for understanding.


```
Run raco pkg install --auto --deps fail --name algorithms
raco pkg install: only one instance of one option from (--deps --auto) is allowed
Error: Process completed with exit code 1.
```

Follow-up to #35.