### PR TITLE
perf: optimize scanl O(n²) --> O(n)

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -114,15 +114,20 @@
     [else (tail-call lst)]))
 
 
-(define (scanl proc lst)
-    (let loop [(acc  (list (car lst)))
-               (val  (car lst))
-               (rest (cdr lst))]
-      (if (empty? rest)
-          (reverse acc)
-          (let [(next (proc val (car rest)))]
-            (loop (cons next acc)
-                  next (cdr rest))))))
+(define scanl
+  (case-lambda
+    [(proc lst)
+     (scanl proc (car lst) (cdr lst))]
+    [(proc seed lst)
+     (let loop ([acc  (list seed)]
+                [val  seed]
+                [rest lst])
+       (if (empty? rest)
+           (reverse acc)
+           (let ([next (proc val (car rest))])
+             (loop (cons next acc)
+                   next
+                   (cdr rest)))))]))
  
 
 (define (scanr proc lst)

--- a/main.rkt
+++ b/main.rkt
@@ -115,12 +115,15 @@
 
 
 (define (scanl proc lst)
-  (foldl
-   (λ (val acc)
-     (append acc (list (proc val (last acc)))))
-   (list (first lst))
-   (rest lst)))
-
+    (let loop [(acc  (list (car lst)))
+               (val  (car lst))
+               (rest (cdr lst))]
+      (if (empty? rest)
+          (reverse acc)
+          (let [(next (proc val (car rest)))]
+            (loop (cons next acc)
+                  next (cdr rest))))))
+ 
 
 (define (scanr proc lst)
   (foldl


### PR DESCRIPTION
`append` and `last` are both O(n), so calling them in a loop resulted in O(n²) time-complexity.

The PR replaces them with a plain loop that accumulates results using cons and reverses them.

I hope the code fits the expected style.

## Benchmark

```rkt
(time (void (scanl-ref + (range #e1e5))))
;; cpu time: 74668 real time: 75829 gc time: 11320

(time (void (scanl + (range #e1e5))))
;; cpu time: 2 real time: 2 gc time: 0
```

With a 100,000-element list, the new implementation is ~38,000x faster.

## Tests

```
stas@thinkpad-t14 ~/P/racket-algorithms (scanl)> raco test main.rkt
raco test: (submod (file "main.rkt") test)
72 tests passed
```